### PR TITLE
Handle error when using fqpn for backup file

### DIFF
--- a/roles/ansible_role_homeassistant/tasks/restore_from_backup.yml
+++ b/roles/ansible_role_homeassistant/tasks/restore_from_backup.yml
@@ -43,7 +43,7 @@
 
 - name: Untar backupfile on remote
   ansible.builtin.unarchive:
-    src: /home/{{ ha_user }}/ha_backup_restore/{{ ha_backup }}
+    src: /home/{{ ha_user }}/ha_backup_restore/{{ ha_backup | basename }}
     dest: /home/{{ ha_user }}/ha_backup_restore/{{ ha_backup[:-4] }}/
     owner: "{{ ha_user }}"
     group: "{{ ha_group }}"


### PR DESCRIPTION
When using a full qualified path name for the backup file, the path is gonna be included during untar process.
But the backup file is uploaded in a flat way.

To solve this, only the basename should be used.